### PR TITLE
feat: support `test-url` for `getSurgeNodes`

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -271,6 +271,7 @@ export interface SimpleNodeConfig {
   hostnameIp?: ReadonlyArray<string>;
   provider?: Provider;
   underlyingProxy?: string;
+  testUrl?: string;
 }
 
 export interface PlainObject {

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -176,6 +176,9 @@ export const getSurgeNodes = function (
                   'tfo',
                   'mptcp',
                 ]),
+                ...(typeof config.testUrl === 'string'
+                  ? [`test-url=${config.testUrl}`]
+                  : []),
                 ...(typeof config.underlyingProxy === 'string'
                   ? [`underlying-proxy=${config.underlyingProxy}`]
                   : []),
@@ -200,6 +203,9 @@ export const getSurgeNodes = function (
                 'tfo',
                 'mptcp',
               ]),
+              ...(typeof config.testUrl === 'string'
+                ? [`test-url=${config.testUrl}`]
+                : []),
               ...(typeof config.underlyingProxy === 'string'
                 ? [`underlying-proxy=${config.underlyingProxy}`]
                 : []),
@@ -223,6 +229,9 @@ export const getSurgeNodes = function (
                 : []),
               ...(typeof config.underlyingProxy === 'string'
                 ? [`underlying-proxy=${config.underlyingProxy}`]
+                : []),
+              ...(typeof config.testUrl === 'string'
+                ? [`test-url=${config.testUrl}`]
                 : []),
               ...pickAndFormatStringList(config, [
                 'sni',
@@ -248,6 +257,9 @@ export const getSurgeNodes = function (
               ...(typeof config.underlyingProxy === 'string'
                 ? [`underlying-proxy=${config.underlyingProxy}`]
                 : []),
+              ...(typeof config.testUrl === 'string'
+                ? [`test-url=${config.testUrl}`]
+                : []),
               ...pickAndFormatStringList(config, ['tfo', 'mptcp']),
             ].join(', '),
           ].join(' = ');
@@ -264,6 +276,9 @@ export const getSurgeNodes = function (
               config.port,
               ...(typeof config.underlyingProxy === 'string'
                 ? [`underlying-proxy=${config.underlyingProxy}`]
+                : []),
+              ...(typeof config.testUrl === 'string'
+                ? [`test-url=${config.testUrl}`]
                 : []),
               ...pickAndFormatStringList(config, [
                 'psk',
@@ -398,6 +413,10 @@ export const getSurgeNodes = function (
               configList.push(`underlying-proxy=${config['underlyingProxy']}`);
             }
 
+            if (config['testUrl']) {
+              configList.push(`test-url=${config['testUrl']}`);
+            }
+
             return [config.nodeName, configList.join(', ')].join(' = ');
           } else {
             // Using external provider
@@ -463,6 +482,9 @@ export const getSurgeNodes = function (
               'sni',
               'tls13',
             ]),
+            ...(typeof nodeConfig.testUrl === 'string'
+                ? [`test-url=${nodeConfig.testUrl}`]
+                : []),
             ...(typeof nodeConfig.underlyingProxy === 'string'
               ? [`underlying-proxy=${nodeConfig.underlyingProxy}`]
               : []),
@@ -482,6 +504,9 @@ export const getSurgeNodes = function (
             ...(typeof nodeConfig.underlyingProxy === 'string'
               ? [`underlying-proxy=${nodeConfig.underlyingProxy}`]
               : []),
+            ...(typeof nodeConfig.testUrl === 'string'
+              ? [`test-url=${nodeConfig.testUrl}`]
+                : []),
             ...pickAndFormatStringList(nodeConfig, [
               'username',
               'password',

--- a/test/utils/index.test.ts
+++ b/test/utils/index.test.ts
@@ -416,6 +416,35 @@ test('getSurgeNodes', async (t) => {
     ]),
     'socks node 3 = socks5, 1.1.1.1, 80, username=auto, password=auto, tfo=true'
   );
+
+  t.is(
+      utils.getSurgeNodes([
+        {
+          type: NodeTypeEnum.Vmess,
+          alterId: '64',
+          hostname: '1.1.1.1',
+          method: 'auto',
+          network: 'ws',
+          nodeName: '测试 6',
+          path: '/',
+          port: 8080,
+          tls: true,
+          tls13: true,
+          skipCertVerify: true,
+          host: '',
+          uuid: '1386f85e-657b-4d6e-9d56-78badb75e1fd',
+          binPath: '/usr/local/bin/v2ray',
+          localPort: 61101,
+          surgeConfig: {
+            v2ray: 'native',
+          },
+          tfo: true,
+          mptcp: true,
+          testUrl: 'http://www.google.com',
+        },
+      ]),
+      '测试 6 = vmess, 1.1.1.1, 8080, username=1386f85e-657b-4d6e-9d56-78badb75e1fd, ws=true, ws-path=/, ws-headers="host:1.1.1.1|user-agent:Mozilla/5.0 (iPhone; CPU iPhone OS 13_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1", tls=true, tls13=true, skip-cert-verify=true, tfo=true, mptcp=true, test-url=http://www.google.com'
+  );
 });
 
 test('getNodeNames', async (t) => {


### PR DESCRIPTION
see: https://community.nssurge.com/d/464