### PR TITLE
:sparkles: provider 支持异步函数的导入方式

### DIFF
--- a/lib/generator/artifact.ts
+++ b/lib/generator/artifact.ts
@@ -325,7 +325,13 @@ export class Artifact extends EventEmitter {
     let nodeConfigList: ReadonlyArray<PossibleNodeConfigType>;
 
     try {
-      provider = getProvider(providerName, require(filePath));
+      // 支持异步函数的模式导入
+      const providerHandle = require(filePath);
+      if (typeof providerHandle === 'function') {
+        provider = getProvider(providerName, await providerHandle());
+      } else {
+        provider = getProvider(providerName, providerHandle);
+      }
       this.providerMap.set(providerName, provider);
     } catch (err) /* istanbul ignore next */ {
       err.message = `处理 ${providerName} 时出现错误，相关文件 ${filePath} ，错误原因: ${err.message}`;


### PR DESCRIPTION
我的场景是搭建了一个回家的节点，正常情况下是使用域名链接的，但是在公司内网的场景下，用于`DDNS`域名的是被`ban`掉的（白名单制）
所以我需要定时去获取域名的 `ip` 地址，然后再回写到 `proxies` 中，生成新的配置，所以需要支持下异步函数的模式