### PR TITLE
feat: add `underlyingProxy` support to `provider`

### DIFF
--- a/docs/guide/custom-provider.md
+++ b/docs/guide/custom-provider.md
@@ -620,6 +620,19 @@ module.exports = {
 
 是否为该订阅强制开启 TFO（TCP Fast Open）。部分机场虽然支持 TFO 但是没有在订阅中开启，你可以通过这个配置强制打开。
 
+### provider.underlyingProxy
+
+- 类型: `string`
+- 默认值: `undefined`
+
+是否对节点使用自定义 underlyingProxy。如果你希望使用自己的落地节点，仅使用进行机场流量转发，可以在这里配置自己的节点作为 underlyingProxy。
+
+目前仅 Surge 支持该特性。
+
+:::warning 注意
+Surgio 不会验证名称是否有效
+:::
+
 ### provider.mptcp
 
 - 类型: `boolean`

--- a/lib/generator/artifact.ts
+++ b/lib/generator/artifact.ts
@@ -425,6 +425,11 @@ export class Artifact extends EventEmitter {
             nodeConfig.tfo = provider.tfo;
           }
 
+          // Underlying Proxy
+          if (provider.underlyingProxy) {
+            nodeConfig.underlyingProxy = provider.underlyingProxy;
+          }
+
           // MPTCP
           if (provider.mptcp) {
             nodeConfig.mptcp = provider.mptcp;

--- a/lib/provider/Provider.ts
+++ b/lib/provider/Provider.ts
@@ -32,6 +32,7 @@ export default class Provider {
   public readonly addFlag?: boolean;
   public readonly removeExistingFlag?: boolean;
   public readonly tfo?: boolean;
+  public readonly underlyingProxy?: string;
   public readonly mptcp?: boolean;
   public readonly renameNode?: ProviderConfig['renameNode'];
   public readonly relayUrl?: boolean | string;
@@ -81,6 +82,7 @@ export default class Provider {
       removeExistingFlag: Joi.boolean().strict(),
       mptcp: Joi.boolean().strict(),
       tfo: Joi.boolean().strict(),
+      underlyingProxy: Joi.string(),
       startPort: Joi.number().integer().min(1024).max(65535),
       relayUrl: [Joi.boolean().strict(), Joi.string()],
       renameNode: Joi.function(),


### PR DESCRIPTION
In some cases, we may just want to use proxy providers only proxy our traffic without letting them decrypt the data. 

`underlyingProxy` is a good feature to achieve this goal, but too complex for users to manually configure them in each node. This PR provided a provider level config rewrite method, letting users can add `underlyingProxy` to all nodes in same provider.