### PR TITLE
fix: clash doesn't support snell v4 yet.

### DIFF
--- a/lib/utils/clash.ts
+++ b/lib/utils/clash.ts
@@ -133,6 +133,13 @@ export const getClashNodes = function (
         }
 
         case NodeTypeEnum.Snell:
+          if (Number(nodeConfig.version) >= 4) {
+            if (!nodeConfig.clashConfig?.enableTuic) {
+              logger.warn(
+                `Clash尚不支持Snell v${nodeConfig.version}，节点 ${nodeConfig.nodeName} 会被省略。`,
+              );
+              return null;
+          }
           return {
             type: 'snell',
             name: nodeConfig.nodeName,

--- a/lib/utils/clash.ts
+++ b/lib/utils/clash.ts
@@ -134,11 +134,10 @@ export const getClashNodes = function (
 
         case NodeTypeEnum.Snell:
           if (Number(nodeConfig.version) >= 4) {
-            if (!nodeConfig.clashConfig?.enableTuic) {
-              logger.warn(
-                `Clash尚不支持Snell v${nodeConfig.version}，节点 ${nodeConfig.nodeName} 会被省略。`,
-              );
-              return null;
+            logger.warn(
+              `Clash尚不支持Snell v${nodeConfig.version}，节点 ${nodeConfig.nodeName} 会被省略。`,
+            );
+            return null;
           }
           return {
             type: 'snell',


### PR DESCRIPTION
If there's a Snell v4 node in config, there will be an error like
```
FATA[0000] Parse config error: proxy 102: snell version error: 4
```