### PR TITLE
fix: remote snippets containing `IP-ASN` with `no-resolve`

### DIFF
--- a/src/utils/remote-snippet.ts
+++ b/src/utils/remote-snippet.ts
@@ -88,6 +88,7 @@ export const addProxyToSurgeRuleSet = (
           return `${item},${proxyName}`
         case 'IP-CIDR':
         case 'IP-CIDR6':
+        case 'IP-ASN':
         case 'GEOIP':
           rule.splice(2, 0, proxyName)
           return rule.join(',')


### PR DESCRIPTION
before: IP-ASN,211157,no-resolve,🚀 Proxy
after:  IP-ASN,211157,🚀 Proxy,no-resolve