### PR TITLE
feat: getClashNodeNames 增加默认节点

### DIFF
--- a/docs/guide/custom-template.md
+++ b/docs/guide/custom-template.md
@@ -295,11 +295,12 @@ ss://cmM0LW1kNTpwYXNzd29yZA@hk.com:1234/?group=subscribe_demo#%F0%9F%87%AD%F0%9F
 
 ### getClashNodeNames
 
-`getClashNodeNames(nodeList, filter?, prependNodeNames?)`
+`getClashNodeNames(nodeList, filter?, prependNodeNames?, defaultNodeNames?)`
 
 :::tip 提示
 - `filter` 为可选参数
 - `prependNodeNames` 为可选参数。可以通过这个参数在过滤结果前加入自定义节点名
+- `defaultNodeNames` 为可选参数。可以通过这个参数实现在过滤结果为空的情况下，使用默认的自定义节点名
 - [Clash 规则维护指南](/guide/client/clash.md)
 :::
 
@@ -315,6 +316,12 @@ getClashNodeNames(nodeList, netflixFilter);
 
 ```js
 getClashNodeNames(nodeList, netflixFilter, ['测试节点']);
+```
+
+需要过滤 Netflix 节点，如果没有 Netflix 相关节点，则使用 `默认节点`
+
+```js
+getClashNodeNames(nodeList, netflixFilter, [], ['默认节点']);
 ```
 
 ### getLoonNodes

--- a/src/utils/__tests__/clash.test.ts
+++ b/src/utils/__tests__/clash.test.ts
@@ -41,7 +41,7 @@ test('getClashNodeNames', async (t) => {
   )
   const result4 = clash.getClashNodeNames(
     nodeNameList,
-    (nodeConfig) => nodeConfig.nodeName !== 'Test Node 4',
+    (nodeConfig) => nodeConfig.nodeName === 'Test Node 4',
     [],
     ['DIRECT'],
   )

--- a/src/utils/__tests__/clash.test.ts
+++ b/src/utils/__tests__/clash.test.ts
@@ -39,10 +39,16 @@ test('getClashNodeNames', async (t) => {
     nodeNameList,
     (nodeConfig) => nodeConfig.nodeName !== 'Test Node 3',
   )
-
+  const result4 = clash.getClashNodeNames(
+    nodeNameList,
+    (nodeConfig) => nodeConfig.nodeName !== 'Test Node 4',
+    [],
+    ['DIRECT'],
+  )
   t.deepEqual(result1, ['Test Node 1', 'Test Node 3'])
   t.deepEqual(result2, ['TEST', 'Test Node 1', 'Test Node 3'])
   t.deepEqual(result3, ['Test Node 1'])
+  t.deepEqual(result4, ['DIRECT'])
 
   t.deepEqual(
     clash.getClashNodeNames([

--- a/src/utils/clash.ts
+++ b/src/utils/clash.ts
@@ -48,7 +48,7 @@ export const getClashNodeNames = function (
 
   result = result.concat(getClashNodes(list, filter).map((item) => item.name))
 
-  if(result.length === 0 && defaultNodeNames) {
+  if (result.length === 0 && defaultNodeNames) {
     result = result.concat(defaultNodeNames)
   }
 

--- a/src/utils/clash.ts
+++ b/src/utils/clash.ts
@@ -33,6 +33,7 @@ export const getClashNodeNames = function (
   list: ReadonlyArray<PossibleNodeConfigType>,
   filter?: NodeFilterType | SortedNodeFilterType,
   prependNodeNames?: ReadonlyArray<string>,
+  defaultNodeNames?: ReadonlyArray<string>,
 ): ReadonlyArray<string> {
   // istanbul ignore next
   if (arguments.length === 2 && typeof filter === 'undefined') {
@@ -46,6 +47,10 @@ export const getClashNodeNames = function (
   }
 
   result = result.concat(getClashNodes(list, filter).map((item) => item.name))
+
+  if(result.length === 0 && defaultNodeNames) {
+    result = result.concat(defaultNodeNames)
+  }
 
   return result
 }


### PR DESCRIPTION
```
- name: Test
  type: select
  proxies: {{ getClashNodeNames(
         nodeList, 
         customFilters.Test, 
         [ ], 
         [ '🚀 Proxy' ]
    ) | json }}
```

我期望 `getClashNodeNames` 达到的效果如下：
- 查询到节点时，使用查询到的节点
- 没有查询到节点时，使用默认配置的 `🚀 Proxy` 节点

现有的 `prependNodeNames` 不管是否查询到，都会追加到最前面，不太符合要求