### PR TITLE
导出 sing-box 配置中的 vless 节点不能包含 security 属性

### DIFF
--- a/src/utils/singbox.ts
+++ b/src/utils/singbox.ts
@@ -117,9 +117,9 @@ function nodeListMapper(nodeConfig: PossibleNodeConfigType) {
 
     case NodeTypeEnum.Vless:
     case NodeTypeEnum.Vmess: {
-      node.security = nodeConfig.method
       node.uuid = nodeConfig.uuid
       if (nodeConfig.type === NodeTypeEnum.Vmess) {
+        node.security = nodeConfig.method
         if (nodeConfig.alterId) {
           node.alter_id = Number(nodeConfig.alterId)
         }


### PR DESCRIPTION
目前导出 sing-box 配置中的vless 节点中包含 security 属性，sing-box 会报错。
sing-box 配置里，vmess 节点有 recurity 属性，vless 没有。