### PR TITLE
feat(singbox): Support network=tcp in VMESS/VLESS

### DIFF
--- a/src/utils/__tests__/singbox.test.ts
+++ b/src/utils/__tests__/singbox.test.ts
@@ -123,7 +123,7 @@ const nodeList: ReadonlyArray<PossibleNodeConfigType> = [
     mux: true,
   },
   {
-    nodeName: 'vmess.tcpNotSupported',
+    nodeName: 'vmess.tcp',
     type: NodeTypeEnum.Vmess,
     hostname: 'example.com',
     port: 443,
@@ -261,7 +261,7 @@ const nodeList: ReadonlyArray<PossibleNodeConfigType> = [
     },
   },
   {
-    nodeName: 'vless.tcpNotSupported',
+    nodeName: 'vless.tcp',
     type: NodeTypeEnum.Vless,
     hostname: 'example.com',
     port: 443,
@@ -670,6 +670,15 @@ const expectedNodes: Record<string, any>[] = [
   },
   {
     type: 'vmess',
+    tag: 'vmess.tcp',
+    server: 'example.com',
+    server_port: 443,
+    security: 'auto',
+    uuid: '1386f85e-657b-4d6e-9d56-78badb75e1fd',
+    alter_id: 0,
+  },
+  {
+    type: 'vmess',
     tag: 'vmess.complex',
     security: 'auto',
     uuid: '1386f85e-657b-4d6e-9d56-78badb75e1fd',
@@ -757,6 +766,19 @@ const expectedNodes: Record<string, any>[] = [
       host: 'example.com',
       path: '/foo',
       headers: { Host: ['example.com'] },
+    },
+  },
+  {
+    type: 'vless',
+    tag: 'vless.tcp',
+    server: 'example.com',
+    server_port: 443,
+    uuid: '1386f85e-657b-4d6e-9d56-78badb75e1fd',
+    flow: 'xtls-rprx-vision',
+    tls: {
+      enabled: true,
+      utls: { enabled: true, fingerprint: 'chrome2' },
+      reality: { enabled: true, public_key: 'publicKey', short_id: 'shortId' },
     },
   },
   {

--- a/src/utils/singbox.ts
+++ b/src/utils/singbox.ts
@@ -187,6 +187,9 @@ function nodeListMapper(nodeConfig: PossibleNodeConfigType) {
           }
           break
 
+        case 'tcp':
+          break
+
         default:
           logger.warn(
             `sing-box 的 ${nodeConfig.type} 节点不支持 network=${nodeConfig.network}，节点 ${nodeConfig.nodeName} 会被忽略`,


### PR DESCRIPTION
singbox 的 vmess/vless 节点不用必须指定 transport ，也就是 surgio 里的 network 可以是默认值 tcp 。
我的 server 端用 singbox 配置的 vless+vision+reality 节点，本地修改后测试连接成功。
不过没有 vmess 节点，因此只测试了 vless ，并未测试 vmess ，只是根据文档中描述 transport 为非必须项，