### PR TITLE
fix(utils): HTTP(S) optional username & password

### DIFF
--- a/src/utils/surfboard.ts
+++ b/src/utils/surfboard.ts
@@ -89,8 +89,8 @@ function nodeListMapper(
             'https',
             nodeConfig.hostname,
             nodeConfig.port,
-            nodeConfig.username,
-            nodeConfig.password,
+            nodeConfig.username /* istanbul ignore next */ || '',
+            nodeConfig.password /* istanbul ignore next */ || '',
             ...(typeof nodeConfig.skipCertVerify === 'boolean'
               ? [`skip-cert-verify=${nodeConfig.skipCertVerify}`]
               : []),
@@ -109,8 +109,8 @@ function nodeListMapper(
             'http',
             nodeConfig.hostname,
             nodeConfig.port,
-            nodeConfig.username,
-            nodeConfig.password,
+            nodeConfig.username /* istanbul ignore next */ || '',
+            nodeConfig.password /* istanbul ignore next */ || '',
           ].join(', '),
         ].join(' = '),
       ]

--- a/src/utils/surge.ts
+++ b/src/utils/surge.ts
@@ -186,8 +186,8 @@ function nodeListMapper(
             'https',
             nodeConfig.hostname,
             nodeConfig.port,
-            nodeConfig.username,
-            nodeConfig.password,
+            nodeConfig.username /* istanbul ignore next */ || '',
+            nodeConfig.password /* istanbul ignore next */ || '',
           ].join(', '),
         ].join(' = '),
       ]
@@ -202,8 +202,8 @@ function nodeListMapper(
             'http',
             nodeConfig.hostname,
             nodeConfig.port,
-            nodeConfig.username,
-            nodeConfig.password,
+            nodeConfig.username /* istanbul ignore next */ || '',
+            nodeConfig.password /* istanbul ignore next */ || '',
           ].join(', '),
         ].join(' = '),
       ]


### PR DESCRIPTION
修复 Clash 配置中含有无用户名密码的 HTTP(S) 节点转换为 Surge 与 Surfboard 节点的错误，如下图⬇️
![IMAGE 2024-11-12 11:39:31](https://github.com/user-attachments/assets/84da49a9-dd8a-4b37-b6e6-ee4a8b3031e1)
