### PR TITLE
fix: clash wireguard config pre-shared-key key name wrong

### DIFF
--- a/src/utils/clash.ts
+++ b/src/utils/clash.ts
@@ -515,10 +515,9 @@ function nodeListMapper(nodeConfig: PossibleNodeConfigType) {
         port: getPortFromHost(nodeConfig.peers[0].endpoint),
         'public-key': nodeConfig.peers[0].publicKey,
         ...(nodeConfig.peers[0].presharedKey
-          ? {
-              'pre-shared-key': nodeConfig.peers[0].presharedKey,
-              'preshared-key': nodeConfig.peers[0].presharedKey,
-            }
+          ? nodeConfig?.clashConfig?.clashCore === 'clash.meta'
+            ? { 'pre-shared-key': nodeConfig.peers[0].presharedKey }
+            : { 'preshared-key': nodeConfig.peers[0].presharedKey }
           : null),
         ...(nodeConfig.peers[0].reservedBits
           ? {

--- a/src/utils/clash.ts
+++ b/src/utils/clash.ts
@@ -515,7 +515,7 @@ function nodeListMapper(nodeConfig: PossibleNodeConfigType) {
         port: getPortFromHost(nodeConfig.peers[0].endpoint),
         'public-key': nodeConfig.peers[0].publicKey,
         ...(nodeConfig.peers[0].presharedKey
-          ? { 'preshared-key': nodeConfig.peers[0].presharedKey }
+          ? { 'pre-shared-key': nodeConfig.peers[0].presharedKey }
           : null),
         ...(nodeConfig.peers[0].reservedBits
           ? {

--- a/src/utils/clash.ts
+++ b/src/utils/clash.ts
@@ -515,7 +515,10 @@ function nodeListMapper(nodeConfig: PossibleNodeConfigType) {
         port: getPortFromHost(nodeConfig.peers[0].endpoint),
         'public-key': nodeConfig.peers[0].publicKey,
         ...(nodeConfig.peers[0].presharedKey
-          ? { 'pre-shared-key': nodeConfig.peers[0].presharedKey }
+          ? {
+              'pre-shared-key': nodeConfig.peers[0].presharedKey,
+              'preshared-key': nodeConfig.peers[0].presharedKey,
+            }
           : null),
         ...(nodeConfig.peers[0].reservedBits
           ? {


### PR DESCRIPTION
According to [config doc](https://wiki.metacubex.one/en/config/proxies/wg), the wg presharedkey config name should be `pre-shared-key`, not `preshared-key`.