### PR TITLE
修复 Netlify 生成配置时报错

### DIFF
--- a/docs/guide/advance/api-gateway/netlify.md
+++ b/docs/guide/advance/api-gateway/netlify.md
@@ -34,6 +34,7 @@
   included_files = [
     "node_modules/surgio/**",
     "node_modules/@surgio/**",
+    "node_modules/compare-versions/**", 
     "provider/**",
     "template/**",
     "*.js",


### PR DESCRIPTION
由于未知原因，Netlify 开始提示 ERROR [ExceptionHandler] Cannot find module 'compare-versions'

检查发现 node_modules 存在 compare-versions 路径

在 netlify.toml 中，添加这一行即可解决
 "node_modules/compare-versions/**",  #