### PR TITLE
style: 修复 PR306 导致的 GitHub Actions Prettier 格式错误

### DIFF
--- a/src/utils/ss.ts
+++ b/src/utils/ss.ts
@@ -35,7 +35,10 @@ export const parseSSUri = (str: string): ShadowsocksNodeConfig => {
       // legacyStr 形如 method:password@host:port
       const atIndex = legacyStr.indexOf('@')
       if (atIndex > 0) {
-        const [cred, hostPort] = [legacyStr.slice(0, atIndex), legacyStr.slice(atIndex + 1)]
+        const [cred, hostPort] = [
+          legacyStr.slice(0, atIndex),
+          legacyStr.slice(atIndex + 1),
+        ]
         const [legacyMethod, legacyPassword] = cred.split(':')
         const [legacyHost, legacyPort] = hostPort.split(':')
         if (legacyMethod && legacyPassword && legacyHost && legacyPort) {


### PR DESCRIPTION
**问题**  
#306 合并后，GitHub Actions 因 `src/utils/ss.ts` 的 Prettier 格式问题失败。

**修复**  
- 调整数组解构换行格式，符合 Prettier 规则
- 纯样式修复，无逻辑变更

**验证**  
- [x] 本地 lint 通过
- [x] 预期 CI 恢复绿色

**关联**  
修复 #306 引入的 CI 报错