### PR TITLE
feat: Add `nodeConfig.serverCertFingerprintSha256` as `fingerprint` for Trojan nodes in Clash

### DIFF
--- a/src/utils/clash.ts
+++ b/src/utils/clash.ts
@@ -354,6 +354,7 @@ function nodeListMapper(nodeConfig: PossibleNodeConfigType) {
         ...(nodeConfig.udpRelay ? { udp: nodeConfig.udpRelay } : null),
         ...(nodeConfig.alpn ? { alpn: nodeConfig.alpn } : null),
         ...(nodeConfig.sni ? { sni: nodeConfig.sni } : null),
+        ...(nodeConfig.serverCertFingerprintSha256 ? { fingerprint: nodeConfig.serverCertFingerprintSha256 } : null),
         'skip-cert-verify': nodeConfig.skipCertVerify === true,
         ...(nodeConfig.network === 'ws'
           ? {


### PR DESCRIPTION
fixes #311