### PR TITLE
chore(provider): Optimize the generation of tuic and Hysteria2 for Surge

### DIFF
--- a/src/provider/ClashProvider.ts
+++ b/src/provider/ClashProvider.ts
@@ -583,12 +583,11 @@ export const parseClashConfig = (
             )
           }
 
-          const hysteria2Port = item.port ?? (item.ports ? Number(item.ports.split('-')[0]) : undefined);
           const input: Hysteria2NodeConfigInput = {
             type: NodeTypeEnum.Hysteria2,
             nodeName: item.name,
             hostname: item.server,
-            port: item.port,
+            port: item.port ?? item.ports,
             password: item.auth || item.password,
             ...(item.down
               ? { downloadBandwidth: parseBitrate(item.down) }

--- a/src/provider/ClashProvider.ts
+++ b/src/provider/ClashProvider.ts
@@ -533,7 +533,7 @@ export const parseClashConfig = (
         case 'tuic': {
           let input;
           const tuicCommonFields = {
-            type: types_1.NodeTypeEnum.Tuic,
+            type: NodeTypeEnum.Tuic,
             nodeName: item.name,
             hostname: item.server,
             port: item.port,

--- a/src/provider/ClashProvider.ts
+++ b/src/provider/ClashProvider.ts
@@ -531,56 +531,38 @@ export const parseClashConfig = (
         }
 
         case 'tuic': {
-          let input: TuicNodeConfigInput
-
-          if (item.version >= 5) {
+          let input;
+          const tuicCommonFields = {
+            type: types_1.NodeTypeEnum.Tuic,
+            nodeName: item.name,
+            hostname: item.server,
+            port: item.port,
+            ...('skip-cert-verify' in item
+              ? { skipCertVerify: item['skip-cert-verify'] === true }
+              : null),
+            tls13: tls13 ?? false,
+            ...('sni' in item ? { sni: item.sni } : null),
+            ...('alpn' in item ? { alpn: item.alpn } : null),
+            ...('ports' in item ? { portHopping: item.ports } : null),
+            ...('hop-interval' in item
+              ? { portHoppingInterval: item['hop-interval'] }
+              : null),
+          };
+          if (item.uuid) {
+            // TuicV5: 含 uuid + password
             input = {
-              type: NodeTypeEnum.Tuic,
-              version: item.version,
-              nodeName: item.name,
-              hostname: item.server,
-              port: item.port,
-              password: item.password,
+              ...tuicCommonFields,
               uuid: item.uuid,
-              ...('skip-cert-verify' in item
-                ? { skipCertVerify: item['skip-cert-verify'] === true }
-                : null),
-              tls13: tls13 ?? false,
-              ...('sni' in item ? { sni: item.sni } : null),
-              ...('alpn' in item ? { alpn: item.alpn } : null),
-              ...('ports' in item
-                ? {
-                    portHopping: item.ports,
-                  }
-                : null),
-              ...('hop-interval' in item
-                ? { portHoppingInterval: item['hop-interval'] }
-                : null),
-            }
-          } else {
-            input = {
-              type: NodeTypeEnum.Tuic,
-              nodeName: item.name,
-              hostname: item.server,
-              port: item.port,
-              token: item.token,
-              ...('skip-cert-verify' in item
-                ? { skipCertVerify: item['skip-cert-verify'] === true }
-                : null),
-              tls13: tls13 ?? false,
-              ...('sni' in item ? { sni: item.sni } : null),
-              ...('alpn' in item ? { alpn: item.alpn } : null),
-              ...('ports' in item
-                ? {
-                    portHopping: item.ports,
-                  }
-                : null),
-              ...('hop-interval' in item
-                ? { portHoppingInterval: item['hop-interval'] }
-                : null),
-            }
+              password: item.password,
+            };
           }
-
+          else {
+            // TuicV4: 含 token
+            input = {
+              ...tuicCommonFields,
+              token: item.token,
+            };
+          }
           const result = TuicNodeConfigValidator.safeParse(input)
 
           // istanbul ignore next
@@ -601,6 +583,7 @@ export const parseClashConfig = (
             )
           }
 
+          const hysteria2Port = item.port ?? (item.ports ? Number(item.ports.split('-')[0]) : undefined);
           const input: Hysteria2NodeConfigInput = {
             type: NodeTypeEnum.Hysteria2,
             nodeName: item.name,

--- a/src/utils/clash.ts
+++ b/src/utils/clash.ts
@@ -413,7 +413,7 @@ function nodeListMapper(nodeConfig: PossibleNodeConfigType) {
         )
       }
 
-      if ('version' in nodeConfig && Number(nodeConfig.version) >= 5) {
+      if ('uuid' in nodeConfig) {
         return {
           type: 'tuic',
           name: nodeConfig.nodeName,

--- a/src/utils/surge.ts
+++ b/src/utils/surge.ts
@@ -457,8 +457,12 @@ function nodeListMapper(
         [
           `${nodeConfig.nodeName} = hysteria2`,
           nodeConfig.hostname,
-          (typeof nodeConfig.port === "string" && nodeConfig.port.includes("-") ? nodeConfig.port.split("-")[0] : nodeConfig.port),
-          ...(0, _1.pickAndFormatStringList)(nodeConfig, ['password', 'downloadBandwidth'], 
+          (typeof nodeConfig.port === 'string' && nodeConfig.port.includes('-')
+            ? nodeConfig.port.split('-')[0]
+            : String(nodeConfig.port)),
+          ...pickAndFormatStringList(
+            nodeConfig,
+            ['password', 'downloadBandwidth'],
             {
               keyFormat: 'kebabCase',
             },
@@ -537,7 +541,7 @@ function appendCommonConfig(
     appendConfig.push(
       ...('alpn' in nodeConfig && Array.isArray(nodeConfig.alpn)
         ? (() => {
-          const preferred = ['h3', 'h2', 'http/1.1'].find((a) => nodeConfig.alpn.includes(a))
+          const preferred = ['h3', 'h2', 'http/1.1'].find((a) => alpn.includes(a))
           return [`alpn=${preferred ?? nodeConfig.alpn[0]}`]
         })()
         : []),

--- a/src/utils/surge.ts
+++ b/src/utils/surge.ts
@@ -541,7 +541,7 @@ function appendCommonConfig(
     appendConfig.push(
       ...('alpn' in nodeConfig && Array.isArray(nodeConfig.alpn)
         ? (() => {
-          const preferred = ['h3', 'h2', 'http/1.1'].find((a) => alpn.includes(a))
+          const preferred = ['h3', 'h2', 'http/1.1'].find((p) => alpn.includes(p))
           return [`alpn=${preferred ?? nodeConfig.alpn[0]}`]
         })()
         : []),

--- a/src/utils/surge.ts
+++ b/src/utils/surge.ts
@@ -406,7 +406,7 @@ function nodeListMapper(
     }
 
     case NodeTypeEnum.Tuic: {
-      if ('version' in nodeConfig && Number(nodeConfig.version) === 5) {
+      if ('uuid' in nodeConfig) {
         const result = [
           'tuic-v5',
           nodeConfig.hostname,
@@ -535,12 +535,12 @@ function appendCommonConfig(
     ...parseShadowTlsConfig(nodeConfig),
   ]
 
-  if (nodeConfig.type === NodeTypeEnum.Tuic) {
-    appendConfig.push(
-      ...('alpn' in nodeConfig && Array.isArray(nodeConfig.alpn)
-        ? [`alpn=${nodeConfig.alpn.join(',')}`]
-        : []),
-    )
+  if (nodeConfig.type === types_1.NodeTypeEnum.Tuic) {
+    if ('alpn' in nodeConfig && Array.isArray(nodeConfig.alpn) && nodeConfig.alpn.length > 0) {
+      const preferredAlpn = ["h3", "h2", "http/1.1"].find(function (a) { return nodeConfig.alpn.includes(a); });
+      const selectedAlpn = preferredAlpn !== undefined ? preferredAlpn : nodeConfig.alpn[0];
+      appendConfig.push("alpn=" + selectedAlpn);
+    }
   }
 
   if (!appendConfig.length) {

--- a/src/utils/surge.ts
+++ b/src/utils/surge.ts
@@ -543,6 +543,7 @@ function appendCommonConfig(
         ? (() => {
           const preferred = ['h3', 'h2', 'http/1.1'].find((p) => alpn.includes(p))
           return [`alpn=${preferred ?? nodeConfig.alpn[0]}`]
+          appendConfig.push('alpn=' + selectedAlpn)
         })()
         : []),
     )

--- a/src/utils/surge.ts
+++ b/src/utils/surge.ts
@@ -457,10 +457,8 @@ function nodeListMapper(
         [
           `${nodeConfig.nodeName} = hysteria2`,
           nodeConfig.hostname,
-          nodeConfig.port,
-          ...pickAndFormatStringList(
-            nodeConfig,
-            ['password', 'downloadBandwidth'],
+          (typeof nodeConfig.port === "string" && nodeConfig.port.includes("-") ? nodeConfig.port.split("-")[0] : nodeConfig.port),
+          ...(0, _1.pickAndFormatStringList)(nodeConfig, ['password', 'downloadBandwidth'], 
             {
               keyFormat: 'kebabCase',
             },

--- a/src/utils/surge.ts
+++ b/src/utils/surge.ts
@@ -533,12 +533,15 @@ function appendCommonConfig(
     ...parseShadowTlsConfig(nodeConfig),
   ]
 
-  if (nodeConfig.type === types_1.NodeTypeEnum.Tuic) {
-    if ('alpn' in nodeConfig && Array.isArray(nodeConfig.alpn) && nodeConfig.alpn.length > 0) {
-      const preferredAlpn = ["h3", "h2", "http/1.1"].find(function (a) { return nodeConfig.alpn.includes(a); });
-      const selectedAlpn = preferredAlpn !== undefined ? preferredAlpn : nodeConfig.alpn[0];
-      appendConfig.push("alpn=" + selectedAlpn);
-    }
+  if (nodeConfig.type === NodeTypeEnum.Tuic) {
+    appendConfig.push(
+      ...('alpn' in nodeConfig && Array.isArray(nodeConfig.alpn)
+        ? (() => {
+          const preferred = ['h3', 'h2', 'http/1.1'].find((a) => nodeConfig.alpn.includes(a))
+          return [`alpn=${preferred ?? nodeConfig.alpn[0]}`]
+        })()
+        : []),
+    )
   }
 
   if (!appendConfig.length) {

--- a/src/validators/hysteria2.ts
+++ b/src/validators/hysteria2.ts
@@ -6,6 +6,10 @@ import { TlsNodeConfigValidator } from './common'
 
 export const Hysteria2NodeConfigValidator = TlsNodeConfigValidator.extend({
   type: z.literal(NodeTypeEnum.Hysteria2),
+  port: zod_1.z.union([
+    zod_1.z.number().int().min(0).max(65535),
+    zod_1.z.string().regex(/^\d+(-\d+)?$/),
+  ]),
   password: z.string(),
   downloadBandwidth: z.number().optional(),
   uploadBandwidth: z.number().optional(),

--- a/src/validators/hysteria2.ts
+++ b/src/validators/hysteria2.ts
@@ -6,9 +6,9 @@ import { TlsNodeConfigValidator } from './common'
 
 export const Hysteria2NodeConfigValidator = TlsNodeConfigValidator.extend({
   type: z.literal(NodeTypeEnum.Hysteria2),
-  port: zod_1.z.union([
-    zod_1.z.number().int().min(0).max(65535),
-    zod_1.z.string().regex(/^\d+(-\d+)?$/),
+  port: z.union([
+    z.number().int().min(0).max(65535),
+    z.string().regex(/^\d+(-\d+)?$/),
   ]),
   password: z.string(),
   downloadBandwidth: z.number().optional(),

--- a/src/validators/tuic.ts
+++ b/src/validators/tuic.ts
@@ -16,6 +16,6 @@ export const TuicNodeV4ConfigValidator = TlsNodeConfigValidator.extend({
 })
 
 export const TuicNodeConfigValidator = z.union([
-  TuicNodeV4ConfigValidator,
   TuicNodeV5ConfigValidator,
+  TuicNodeV4ConfigValidator,
 ])

--- a/src/validators/tuic.ts
+++ b/src/validators/tuic.ts
@@ -8,7 +8,6 @@ export const TuicNodeV5ConfigValidator = TlsNodeConfigValidator.extend({
   type: z.literal(NodeTypeEnum.Tuic),
   password: z.string(),
   uuid: z.string(),
-  version: IntegersVersionValidator,
 })
 
 export const TuicNodeV4ConfigValidator = TlsNodeConfigValidator.extend({


### PR DESCRIPTION
## Tuic

### 使用 uuid 判断 tuic 协议的版本
```
[token]
必须，用于 TUIC V4 的用户标识，使用 TUIC V5 时不可书写

[uuid]
必须，用于 TUICV5 的用户唯一识别码，使用 TUIC V4 时不可书写

[password]
必须，用于 TUICV5 的用户密码，使用 TUIC V4 时不可书写
```

### Surge 仅支持配置单个`alpn`值,当 `alpn` 有多个值传入时，例如
```
alpn:
  - h3
  - h2
  - http/1.1
```
 - 采用优先级为 h3>h2>http/1.1
- 如果都没有则传入首个值


## hysteria2
### 只传入`ports`端口跳跃范围时，如：`ports: 10001-11000`
```
- ClashProvider：port: item.port ?? item.ports'→ 原始值 "10001-11000" 直接传入
- hysteria2.js validator：port 同时接受整数或 "13001-14000" 格式字符串，校验通过
- surge.js 输出层：生成配置时截取 - 前的起始端口 10001 作为端口号
```