### PR TITLE
fix(utils): prioritize common ALPN protocols and use a single ALPN for Tuic nodes in Surge configuration.

### DIFF
--- a/src/utils/surge.ts
+++ b/src/utils/surge.ts
@@ -538,7 +538,13 @@ function appendCommonConfig(
   if (nodeConfig.type === NodeTypeEnum.Tuic) {
     appendConfig.push(
       ...('alpn' in nodeConfig && Array.isArray(nodeConfig.alpn)
-        ? [`alpn=${nodeConfig.alpn.join(',')}`]
+        ? (() => {
+            const alpn = nodeConfig.alpn as string[]
+            const preferred = ['h3', 'h2', 'http/1.1'].find((a) =>
+              alpn.includes(a),
+            )
+            return [`alpn=${preferred ?? alpn[0]}`]
+          })()
         : []),
     )
   }


### PR DESCRIPTION
### Bug 修复: 生成 Surge 配置时，TUIC 只配置单个 `alpn` 值（ 优先选取 [h3] ）

---
**关键**：
在 Surge 中， TUIC 仅支持配置单个`alpn`值

**复现**：
当 `alpn` 有多个值传入时，例如：
```
alpn:
  - h3
  - h2
  - http/1.1
```
则输出结果为：`alpn: h3,h2.http/1.1`，导致 Surge 无法正常启动

**改进**：
遇到上述情况时，预期输出为: `alpn: h3`

- 采用优先级为 `h3 > h2 > http/1.1`
- 无匹配时 fallback 取第一个值
