### PR TITLE
fix(provider): preserve reality short-id strings without extra quotes

### DIFF
--- a/src/provider/ClashProvider.ts
+++ b/src/provider/ClashProvider.ts
@@ -221,10 +221,17 @@ export const getClashSubscription = async ({
       keepSourceTokens: true,
     })
     yaml.visit(doc, {
-      Pair: (_, node: any) =>
-        node.key?.value === 'short-id' &&
-        node.value?.srcToken &&
-        (node.value.value = node.value.srcToken.source),
+      Pair: (_, node: any) => {
+        if (
+          node.key?.value !== 'short-id' ||
+          !node.value?.srcToken ||
+          typeof node.value.value === 'string'
+        ) {
+          return
+        }
+
+        node.value.value = String(node.value.srcToken.source).trim()
+      },
     })
     if (doc.errors.length > 0) {
       throw new Error() //yaml.parseDocument语法错误时不会抛出异常, 这里手动丢下(跳转到下面的catch)

--- a/src/provider/__tests__/ClashProvider.test.ts
+++ b/src/provider/__tests__/ClashProvider.test.ts
@@ -314,6 +314,54 @@ test('getClashSubscription udpRelay', async (t) => {
   })
 })
 
+test('getClashSubscription keeps reality short-id as plain string', async (t) => {
+  const scope = nock('http://local')
+    .get('/short-id')
+    .reply(
+      200,
+      `
+proxies:
+  - name: "short-id numeric"
+    type: vless
+    server: server.com
+    port: 443
+    tls: true
+    uuid: uuid-1
+    flow: xtls-rprx-vision
+    reality-opts:
+      public-key: publicKey1
+      short-id: 09561058
+    client-fingerprint: chrome
+  - name: "short-id quoted"
+    type: vless
+    server: server.com
+    port: 443
+    tls: true
+    uuid: uuid-2
+    flow: xtls-rprx-vision
+    reality-opts:
+      public-key: publicKey2
+      short-id: '12'
+    client-fingerprint: chrome
+    `,
+    )
+
+  const { nodeList } = await getClashSubscription({
+    url: 'http://local/short-id',
+    requestHeaders: { 'user-agent': 'clash-for-windows' },
+    cacheKey: 'test-cache-key-short-id',
+  })
+
+  t.deepEqual(
+    nodeList.map((node) =>
+      node.type === NodeTypeEnum.Vless ? node.realityOpts?.shortId : undefined,
+    ),
+    ['09561058', '12'],
+  )
+
+  scope.done()
+})
+
 test('getClashSubscription - invalid yaml', async (t) => {
   const scope = nock('http://local')
     .get('/fail-1')


### PR DESCRIPTION
## Summary

This PR fixes `reality-opts.short-id` parsing in `ClashProvider`.

## Problem

#330 To preserve leading zeros for numeric-looking `short-id` values such as `09561058`, the current implementation reads the raw YAML token value directly.

That fixes the leading zero issue, but it also keeps wrapping quotes for quoted values.

For example:

```yaml
short-id: '12'
```

may be parsed and emitted as:

```yaml
"short-id": "'12'"
```

This results in invalid nested quotes in generated Clash output.

## Changes
+ only fall back to raw source text when short-id is parsed as a non-string scalar
+ keep the parsed value when short-id is already a string
+ add a regression test covering both numeric-looking and quoted short-id values