### PR TITLE
feat(provider): 为 Quantumult X 增加 AnyTLS 配置转换

### DIFF
--- a/docs/guide/custom-provider.md
+++ b/docs/guide/custom-provider.md
@@ -551,7 +551,7 @@ Clash 需要在配置中开启 `clashConfig.enableHysteria2`。
 
 > <Badge text="Surgio v3.13.0" vertical="middle" />
 
-当前支持为 Clash、Surge 和 sing-box 生成 AnyTLS 节点。
+当前支持为 Clash、Surge、sing-box 和 Quantumult X 生成 AnyTLS 节点。
 
 ```json5
 {
@@ -562,6 +562,10 @@ Clash 需要在配置中开启 `clashConfig.enableHysteria2`。
   password: 'password',
   udpRelay: false, // 可选
   sni: 'sni.example.com', // 可选
+  realityOpts: {
+    publicKey: 'public-key',
+    shortId: 'short-id', // 可选
+  }, // 可选，仅 Quantumult X Reality TLS 输出使用
   alpn: ['h2', 'http/1.1'], // 可选
   skipCertVerify: false, // 可选
   idleSessionCheckInterval: 0, // 可选

--- a/docs/guide/custom-template.md
+++ b/docs/guide/custom-template.md
@@ -271,7 +271,7 @@ ss://cmM0LW1kNTpwYXNzd29yZA@hk.com:1234/?group=subscribe_demo#%F0%9F%87%AD%F0%9F
 :::tip 提示
 
 - 第二个参数可选，可传入标准的过滤器或自定义的过滤器
-- 支持输出 Shadowsocks, Shadowsocksr, Vmess, HTTPS, Trojan 节点
+- 支持输出 Shadowsocks, Shadowsocksr, Vmess, HTTPS, Trojan, AnyTLS 节点
 - 支持添加 `udp-relay` 和 `fast-open` 配置
 :::
 

--- a/src/utils/__tests__/quantumult.test.ts
+++ b/src/utils/__tests__/quantumult.test.ts
@@ -277,6 +277,61 @@ test('getQuantumultXNodes', (t) => {
   t.is(
     quantumult.getQuantumultXNodes([
       {
+        type: NodeTypeEnum.AnyTLS,
+        nodeName: 'anytls',
+        hostname: 'example.com',
+        port: 443,
+        password: 'password1',
+      },
+    ]),
+    'anytls=example.com:443, password=password1, over-tls=true, tls-verification=true, tag=anytls',
+  )
+
+  t.is(
+    quantumult.getQuantumultXNodes([
+      {
+        type: NodeTypeEnum.AnyTLS,
+        nodeName: 'anytls-standard-tls-01',
+        hostname: 'example.com',
+        port: 443,
+        password: 'password1',
+        sni: 'sni.example.com',
+        udpRelay: true,
+        skipCertVerify: true,
+        tfo: true,
+        tls13: true,
+        testUrl: 'http://example.com',
+      },
+    ]),
+    'anytls=example.com:443, password=password1, over-tls=true, tls-host=sni.example.com, tls-verification=false, udp-relay=true, fast-open=true, tls13=true, server_check_url=http://example.com, tag=anytls-standard-tls-01',
+  )
+
+  t.is(
+    quantumult.getQuantumultXNodes([
+      {
+        type: NodeTypeEnum.AnyTLS,
+        nodeName: 'anytls-reality-tls-01',
+        hostname: 'example.com',
+        port: 443,
+        password: 'password1',
+        sni: 'sni.example.com',
+        realityOpts: {
+          publicKey: 'udCD6aJAy_l_rXtv2gRVJmY3n0m7ei08u4mqhF6PgkA',
+          shortId: '0123456789abcdef',
+        },
+        udpRelay: true,
+        skipCertVerify: true,
+        tfo: true,
+        tls13: true,
+        testUrl: 'http://example.com',
+      },
+    ]),
+    'anytls=example.com:443, password=password1, over-tls=true, tls-host=sni.example.com, reality-base64-pubkey=udCD6aJAy_l_rXtv2gRVJmY3n0m7ei08u4mqhF6PgkA, reality-hex-shortid=0123456789abcdef, tls-verification=true, udp-relay=true, fast-open=true, tls13=true, server_check_url=http://example.com, tag=anytls-reality-tls-01',
+  )
+
+  t.is(
+    quantumult.getQuantumultXNodes([
+      {
         type: NodeTypeEnum.Vmess,
         alterId: '64',
         hostname: '1.1.1.1',
@@ -390,6 +445,13 @@ test('getQuantumultXNodeNames', (t) => {
         password: 'password',
       },
       {
+        nodeName: 'AnyTLS Node',
+        type: NodeTypeEnum.AnyTLS,
+        hostname: 'anytls.example.com',
+        port: '443',
+        password: 'password',
+      },
+      {
         enable: false,
         nodeName: 'Test Node 3',
         type: NodeTypeEnum.Shadowsocks,
@@ -399,6 +461,6 @@ test('getQuantumultXNodeNames', (t) => {
         password: 'password',
       },
     ]),
-    ['Test Node 1', 'Test Node 2'].join(', '),
+    ['Test Node 1', 'Test Node 2', 'AnyTLS Node'].join(', '),
   )
 })

--- a/src/utils/quantumult.ts
+++ b/src/utils/quantumult.ts
@@ -310,6 +310,35 @@ function nodeListMapper(
       return [nodeConfig.nodeName, `trojan=${config.join(', ')}`]
     }
 
+    case NodeTypeEnum.AnyTLS: {
+      const config = [
+        `${nodeConfig.hostname}:${nodeConfig.port}`,
+        ...pickAndFormatStringList(nodeConfig, ['password']),
+        'over-tls=true',
+        ...(nodeConfig.sni ? [`tls-host=${nodeConfig.sni}`] : []),
+        ...(nodeConfig.realityOpts?.publicKey
+          ? [`reality-base64-pubkey=${nodeConfig.realityOpts.publicKey}`]
+          : []),
+        ...(nodeConfig.realityOpts?.shortId
+          ? [`reality-hex-shortid=${nodeConfig.realityOpts.shortId}`]
+          : []),
+        `tls-verification=${
+          nodeConfig.realityOpts ? true : nodeConfig.skipCertVerify !== true
+        }`,
+        ...(nodeConfig.udpRelay ? [`udp-relay=true`] : []),
+        ...(nodeConfig.tfo ? [`fast-open=true`] : []),
+        ...(nodeConfig.tls13 ? [`tls13=true`] : []),
+      ]
+
+      if (typeof nodeConfig.testUrl === 'string') {
+        config.push(`server_check_url=${nodeConfig['testUrl']}`)
+      }
+
+      config.push(`tag=${nodeConfig.nodeName}`)
+
+      return [nodeConfig.nodeName, `anytls=${config.join(', ')}`]
+    }
+
     // istanbul ignore next
     default:
       logger.warn(

--- a/src/validators/anytls.ts
+++ b/src/validators/anytls.ts
@@ -4,10 +4,16 @@ import { NodeTypeEnum } from '../types'
 
 import { TlsNodeConfigValidator } from './common'
 
+const AnyTLSRealityOptsValidator = z.object({
+  publicKey: z.string(),
+  shortId: z.ostring(),
+})
+
 export const AnyTLSNodeConfigValidator = TlsNodeConfigValidator.extend({
   type: z.literal(NodeTypeEnum.AnyTLS),
   password: z.string(),
   udpRelay: z.oboolean(),
+  realityOpts: AnyTLSRealityOptsValidator.optional(),
   idleSessionCheckInterval: z.number().optional(),
   idleSessionTimeout: z.number().optional(),
   minIdleSessions: z.number().optional(),

--- a/test/cli.cli-test.ts
+++ b/test/cli.cli-test.ts
@@ -4,7 +4,7 @@ import fs from 'fs-extra'
 import ini from 'ini'
 import { test, expect } from '@oclif/test'
 
-const fixture = join(__dirname, './fixture')
+const fixture = join(process.cwd(), './test/fixture')
 const resolve = (p: string) => join(fixture, p)
 
 afterEach(async () => {

--- a/test/cli.cli-test.ts.snap
+++ b/test/cli.cli-test.ts.snap
@@ -109,6 +109,7 @@ http=us.example.com:443, username=username, password=password, fast-open=true, o
 trojan=trojan.example.com:443, password=password, tls-verification=true, over-tls=true, tag=trojan node
 trojan=trojan.example.com:443, password=password, tls-verification=true, over-tls=true, tag=🚀 火箭 trojan node
 trojan=trojan.example.com:443, password=password, tls-verification=true, over-tls=true, tag=🎉 foobar trojan node
+anytls=anytls.example.com:443, password=password, over-tls=true, tls-verification=true, tag=anytls node
 shadowsocks=us.example.com:443, method=chacha20-ietf-poly1305, password=password, obfs=tls, obfs-host=gateway-carry.icloud.com, tag=🇺🇸US 1
 shadowsocks=us.example.com:444, method=chacha20-ietf-poly1305, password=password, tag=🇺🇸US 2
 shadowsocks=us.example.com:445, method=chacha20-ietf-poly1305, password=password, obfs=tls, obfs-host=www.bing.com, tag=🇺🇸US 3
@@ -134,10 +135,10 @@ getLoonNodes
 🇺🇸US 1 = Shadowsocks,us.example.com,443,chacha20-ietf-poly1305,\\"password\\",tls,gateway-carry.icloud.com,fast-open=true
 🇺🇸US 2 = Shadowsocks,us.example.com,443,chacha20-ietf-poly1305,\\"password\\",fast-open=true
 🇺🇸 US = Shadowsocks,us.example.com,443,chacha20-ietf-poly1305,\\"password\\",tls,gateway-carry.icloud.com,fast-open=true,udp=true
-HTTPS = https,us.example.com,443,username,\\"password\\",tls-name=us.example.com,skip-cert-verify=false
-trojan node = trojan,trojan.example.com,443,\\"password\\",tls-name=trojan.example.com,skip-cert-verify=false
-🚀 火箭 trojan node = trojan,trojan.example.com,443,\\"password\\",tls-name=trojan.example.com,skip-cert-verify=false
-🎉 foobar trojan node = trojan,trojan.example.com,443,\\"password\\",tls-name=trojan.example.com,skip-cert-verify=false
+HTTPS = https,us.example.com,443,username,\\"password\\",sni=us.example.com,skip-cert-verify=false
+trojan node = trojan,trojan.example.com,443,\\"password\\",sni=trojan.example.com,skip-cert-verify=false
+🚀 火箭 trojan node = trojan,trojan.example.com,443,\\"password\\",sni=trojan.example.com,skip-cert-verify=false
+🎉 foobar trojan node = trojan,trojan.example.com,443,\\"password\\",sni=trojan.example.com,skip-cert-verify=false
 🇺🇸US 1 = Shadowsocks,us.example.com,443,chacha20-ietf-poly1305,\\"password\\",tls,gateway-carry.icloud.com
 🇺🇸US 2 = Shadowsocks,us.example.com,444,chacha20-ietf-poly1305,\\"password\\"
 🇺🇸US 3 = Shadowsocks,us.example.com,445,chacha20-ietf-poly1305,\\"password\\",tls,www.bing.com
@@ -510,7 +511,7 @@ http 2 = http, server, 443, username, password
 ss4 = ss, server, 443, encrypt-method=chacha20-ietf-poly1305, password=password, udp-relay=true, obfs=tls, obfs-host=example.com
 ----
 getNodeNames
-ss1, ss2, ss3, vmess, vmess new format, vmess custom header, socks, http 1, http 2, snell, ss4, ss-wss, hysteria2
+ss1, ss2, ss3, vmess, vmess new format, vmess custom header, socks, http 1, http 2, snell, ss4, ss-wss, hysteria2, vless
 ----
 getQuantumultXNodes
 shadowsocks=server:443, method=chacha20-ietf-poly1305, password=password, udp-relay=true, tag=ss1
@@ -523,6 +524,7 @@ http=server:443, username=username, password=password, over-tls=true, tls-verifi
 http=server:443, username=username, password=password, tag=http 2
 shadowsocks=server:443, method=chacha20-ietf-poly1305, password=password, obfs=tls, obfs-host=example.com, udp-relay=true, tag=ss4
 shadowsocks=server:443, method=chacha20-ietf-poly1305, password=password, obfs=wss, obfs-host=cloudflare.com, obfs-uri=/ws, udp-relay=true, tls-verification=true, tls13=true, tag=ss-wss
+vless=server.com:443, method=none, password=uuid, udp-relay=true, aead=true, obfs=over-tls, tls-verification=true, tls13=true, tag=vless
 ----
 getSurgeNodes
 
@@ -530,12 +532,13 @@ getSurgeNodes
 getLoonNodes
 ss1 = Shadowsocks,server,443,chacha20-ietf-poly1305,\\"password\\",udp=true
 ss2 = Shadowsocks,server,443,chacha20-ietf-poly1305,\\"password\\",tls,www.bing.com,udp=true
-vmess = vmess,server,443,chacha20-poly1305,\\"uuid\\",transport=tcp
-vmess new format = vmess,server,443,chacha20-poly1305,\\"uuid\\",transport=ws,path=/path,host=v2ray.com,over-tls=true,skip-cert-verify=true
-vmess custom header = vmess,server,443,chacha20-poly1305,\\"uuid\\",transport=ws,path=/path,over-tls=true
-http 1 = https,server,443,username,\\"password\\",tls-name=server,skip-cert-verify=false
+vmess = vmess,server,443,chacha20-poly1305,\\"uuid\\",transport=tcp,udp=true
+vmess new format = vmess,server,443,chacha20-poly1305,\\"uuid\\",transport=ws,path=/path,host=v2ray.com,over-tls=true,skip-cert-verify=true,udp=true
+vmess custom header = vmess,server,443,chacha20-poly1305,\\"uuid\\",transport=ws,path=/path,over-tls=true,udp=true
+http 1 = https,server,443,username,\\"password\\",sni=server,skip-cert-verify=false
 http 2 = http,server,443,username,\\"password\\"
 ss4 = Shadowsocks,server,443,chacha20-ietf-poly1305,\\"password\\",tls,example.com,udp=true
+vless = VLESS,server.com,443,\\"uuid\\",transport=tcp,flow=xtls-rprx-vision,public-key=\\"666Kuy1l13XTLXaX2m9nV_s6JYRc8C3FRuAT15Bhaba\\",short-id=09561058,over-tls=true,sni=porter.server.com,udp=true
 ----
 proxyTestUrl
 http://www.google.com/generate_204


### PR DESCRIPTION
Quantumult X 已在 1.5.6 (925) 中支持 AnyTLS 协议，据 <https://t.me/QuanXNews/374> ，支持如下两种 TLS 类型：

```
- Standard TLS:
anytls=example.com:443, password=pwd, over-tls=true, tls-host=apple.com, udp-relay=true, tag=anytls-standard-tls-01

- Reality TLS (set reality-base64-pubkey to replace Standard TLS with Reality TLS):
anytls=example.com:443, password=pwd, over-tls=true, tls-host=apple.com, reality-base64-pubkey=k4Uxez0sjl8bKaZH2Vgi8-WDFshML51QkxKFLWFIONk, reality-hex-shortid=0123456789abcdef, udp-relay=true, tag=anytls-reality-tls-01
```

本 PR 内容：
- 为 Quantumult X Provider 增加 AnyTLS 配置转换，含 Standard TLS 和 Reality TLS；
- 修正并确保 Tests 通过，共计 209 Unit tests 和 9 CLI Tests；