### PR TITLE
fix(provider): 修复 Clash 配置中 short-id 数字转换问题(添加类型检查)

### DIFF
--- a/src/provider/ClashProvider.ts
+++ b/src/provider/ClashProvider.ts
@@ -221,10 +221,15 @@ export const getClashSubscription = async ({
       keepSourceTokens: true,
     })
     yaml.visit(doc, {
-      Pair: (_, node: any) =>
-        node.key?.value === 'short-id' &&
-        node.value?.srcToken &&
-        (node.value.value = node.value.srcToken.source),
+      Pair: (_, node: any) => {
+        if (
+          node.key?.value === 'short-id' &&
+          typeof node.value?.value === 'number' && //short-id应是字符串,如果这里是数字,则将srcToken的source赋给value, 避免yaml转换错误, 如: "09561058" 变成 9561058
+          node.value?.srcToken
+        ) {
+          node.value.value = node.value.srcToken.source
+        }
+      },
     })
     if (doc.errors.length > 0) {
       throw new Error() //yaml.parseDocument语法错误时不会抛出异常, 这里手动丢下(跳转到下面的catch)


### PR DESCRIPTION
- 添加类型验证确保只处理数值类型的节点, 仅处理short-id被YAML解析器错误识别为数字类型才从srcToken中取原始值(字符串) 解决当前非数字类型的short-id 在singbox中被多套了层引号的问题, 如: "short_id": "\"6acf2806\""