### PR TITLE
feat: support vless xhttp for mihomo

### DIFF
--- a/src/constant/__tests__/constant.test.ts
+++ b/src/constant/__tests__/constant.test.ts
@@ -4,9 +4,10 @@ import { z } from 'zod'
 
 import {
   CLASH_META_SUPPORTED_VMESS_NETWORK,
+  CLASH_META_SUPPORTED_VLESS_NETWORK,
   V2RAYN_SUPPORTED_VMESS_NETWORK,
 } from '../'
-import { VmessNetworkValidator } from '../../validators'
+import { VlessNetworkValidator, VmessNetworkValidator } from '../../validators'
 
 test('constant', (t) => {
   for (const network of V2RAYN_SUPPORTED_VMESS_NETWORK) {
@@ -15,6 +16,10 @@ test('constant', (t) => {
 
   for (const network of CLASH_META_SUPPORTED_VMESS_NETWORK) {
     expectType<z.infer<typeof VmessNetworkValidator>>(network)
+  }
+
+  for (const network of CLASH_META_SUPPORTED_VLESS_NETWORK) {
+    expectType<z.infer<typeof VlessNetworkValidator>>(network)
   }
 
   t.pass()

--- a/src/constant/constant.ts
+++ b/src/constant/constant.ts
@@ -158,12 +158,22 @@ export const CLASH_META_SUPPORTED_VMESS_NETWORK = [
   'http',
 ] as const
 
+export const CLASH_META_SUPPORTED_VLESS_NETWORK = [
+  ...CLASH_META_SUPPORTED_VMESS_NETWORK,
+  'xhttp',
+] as const
+
 export const STASH_SUPPORTED_VMESS_NETWORK = [
   'tcp',
   'ws',
   'h2',
   'grpc',
   'http',
+] as const
+
+export const STASH_SUPPORTED_VLESS_NETWORK = [
+  ...STASH_SUPPORTED_VMESS_NETWORK,
+  'xhttp',
 ] as const
 
 export const QUANTUMULT_X_SUPPORTED_VMESS_NETWORK = [

--- a/src/provider/ClashProvider.ts
+++ b/src/provider/ClashProvider.ts
@@ -6,7 +6,9 @@ import { z } from 'zod'
 
 import {
   CLASH_META_SUPPORTED_VMESS_NETWORK,
+  CLASH_META_SUPPORTED_VLESS_NETWORK,
   STASH_SUPPORTED_VMESS_NETWORK,
+  STASH_SUPPORTED_VLESS_NETWORK,
 } from '../constant'
 import {
   AnyTLSNodeConfig,
@@ -344,15 +346,20 @@ export const parseClashConfig = (
         case 'vless':
         case 'vmess': {
           // istanbul ignore next
-          if (
-            item.network &&
-            ![
-              ...CLASH_META_SUPPORTED_VMESS_NETWORK,
-              ...STASH_SUPPORTED_VMESS_NETWORK,
-            ].includes(item.network)
-          ) {
+          const supportedNetworks =
+            item.type === 'vless'
+              ? [
+                  ...CLASH_META_SUPPORTED_VLESS_NETWORK,
+                  ...STASH_SUPPORTED_VLESS_NETWORK,
+                ]
+              : [
+                  ...CLASH_META_SUPPORTED_VMESS_NETWORK,
+                  ...STASH_SUPPORTED_VMESS_NETWORK,
+                ]
+
+          if (item.network && !supportedNetworks.includes(item.network)) {
             logger.warn(
-              `不支持从 Clash 订阅中读取 network 类型为 ${item.network} 的 Vmess 节点，节点 ${item.name} 会被省略`,
+              `不支持从 Clash 订阅中读取 network 类型为 ${item.network} 的 ${item.type} 节点，节点 ${item.name} 会被省略`,
             )
             return undefined
           }
@@ -414,6 +421,12 @@ export const parseClashConfig = (
             if (typeof item.encryption === 'string') {
               vmessNode.encryption = item.encryption
             }
+            if (typeof item['packet-encoding'] === 'string') {
+              vmessNode.packetEncoding = item['packet-encoding']
+            }
+            if (item['ech-opts']) {
+              vmessNode.echOpts = item['ech-opts']
+            }
 
             if (item['reality-opts']) {
               vmessNode.realityOpts = {
@@ -462,6 +475,18 @@ export const parseClashConfig = (
             case 'grpc':
               vmessNode.grpcOpts = {
                 serviceName: item['grpc-opts']['grpc-service-name'],
+              }
+
+              break
+            case 'xhttp':
+              if (vmessNode.type !== NodeTypeEnum.Vless) {
+                logger.warn(
+                  `mihomo 仅支持 VLESS 使用 xhttp 传输层，节点 ${item.name} 会被省略`,
+                )
+                return undefined
+              }
+              vmessNode.xhttpOpts = item['xhttp-opts'] || {
+                path: '/',
               }
 
               break

--- a/src/provider/ClashProvider.ts
+++ b/src/provider/ClashProvider.ts
@@ -485,8 +485,9 @@ export const parseClashConfig = (
                 )
                 return undefined
               }
-              vmessNode.xhttpOpts = item['xhttp-opts'] || {
+              vmessNode.xhttpOpts = {
                 path: '/',
+                ...item['xhttp-opts'],
               }
 
               break

--- a/src/provider/CustomProvider.ts
+++ b/src/provider/CustomProvider.ts
@@ -92,6 +92,14 @@ export default class CustomProvider extends Provider {
           throw new Error('obfs-uri 已废弃，请使用 obfsUri')
         }
 
+        if (
+          type === NodeTypeEnum.Vless &&
+          node.network === 'xhttp' &&
+          node.path
+        ) {
+          throw new Error('请将 path 移动到 xhttpOpts.path')
+        }
+
         // istanbul ignore next
         let parsedNode = (() => {
           switch (type) {

--- a/src/provider/__tests__/ClashProvider.test.ts
+++ b/src/provider/__tests__/ClashProvider.test.ts
@@ -636,6 +636,73 @@ test('vmess Configurations', (t) => {
       },
     ],
   )
+
+  t.deepEqual(
+    parseClashConfig([
+      {
+        type: 'vless',
+        name: 'vless-xhttp',
+        server: 'server',
+        port: 443,
+        uuid: 'uuid',
+        cipher: 'none',
+        udp: true,
+        tls: true,
+        network: 'xhttp',
+        'client-fingerprint': 'chrome',
+        'packet-encoding': 'xudp',
+        'xhttp-opts': {
+          path: '/xhttp',
+          mode: 'auto',
+        },
+        'ech-opts': {
+          enable: true,
+          config: 'ech-config',
+        },
+        encryption: 'none',
+      },
+    ]),
+    [
+      {
+        type: NodeTypeEnum.Vless,
+        nodeName: 'vless-xhttp',
+        hostname: 'server',
+        port: 443,
+        uuid: 'uuid',
+        method: 'none',
+        network: 'xhttp',
+        udpRelay: true,
+        clientFingerprint: 'chrome',
+        packetEncoding: 'xudp',
+        xhttpOpts: {
+          path: '/xhttp',
+          mode: 'auto',
+        },
+        echOpts: {
+          enable: true,
+          config: 'ech-config',
+        },
+        skipCertVerify: false,
+        tls13: false,
+        encryption: 'none',
+      },
+    ],
+  )
+
+  t.deepEqual(
+    parseClashConfig([
+      {
+        type: 'vmess',
+        name: 'vmess-xhttp',
+        server: 'server',
+        port: 443,
+        uuid: 'uuid',
+        cipher: 'auto',
+        network: 'xhttp',
+      },
+    ]),
+    [],
+  )
 })
 
 test('snell Configurations', (t) => {

--- a/src/provider/__tests__/CustomProvider.test.ts
+++ b/src/provider/__tests__/CustomProvider.test.ts
@@ -321,3 +321,29 @@ test('CustomProvider rejects vmess path on ws network', async (t) => {
   const error = await t.throwsAsync(() => provider.getNodeList())
   t.true(error?.message.includes('节点配置校验失败'))
 })
+
+test('CustomProvider rejects vless path on xhttp network', async (t) => {
+  const provider = new CustomProvider('test', {
+    type: SupportProviderEnum.Custom,
+    nodeList: [
+      {
+        type: NodeTypeEnum.Vless,
+        nodeName: 'vless-test',
+        hostname: 'example.com',
+        port: 443,
+        method: 'none',
+        uuid: '2e1a3b2a-0a6e-4aa6-9b1f-32b3f4cc0c1a',
+        network: 'xhttp',
+        path: '/legacy',
+        encryption: 'none',
+        tls: true,
+        xhttpOpts: {
+          path: '/xhttp',
+        },
+      } as any,
+    ],
+  })
+
+  const error = await t.throwsAsync(() => provider.getNodeList())
+  t.true(error?.message.includes('节点配置校验失败'))
+})

--- a/src/utils/__tests__/clash.test.ts
+++ b/src/utils/__tests__/clash.test.ts
@@ -642,6 +642,75 @@ test('getClashNodes', async (t) => {
   t.deepEqual(
     clash.getClashNodes([
       {
+        type: NodeTypeEnum.Vless,
+        nodeName: 'vless-xhttp',
+        hostname: 'server',
+        port: 443,
+        uuid: 'uuid',
+        method: 'none',
+        network: 'xhttp',
+        udpRelay: true,
+        flow: 'xtls-rprx-vision',
+        encryption: 'none',
+        packetEncoding: 'xudp',
+        xhttpOpts: {
+          path: '/xhttp',
+          mode: 'auto',
+        },
+        echOpts: {
+          enable: true,
+          config: 'ech-config',
+        },
+        clashConfig: {
+          enableVless: true,
+        },
+      },
+    ]),
+    [
+      {
+        type: 'vless',
+        name: 'vless-xhttp',
+        server: 'server',
+        port: 443,
+        uuid: 'uuid',
+        cipher: 'none',
+        flow: 'xtls-rprx-vision',
+        udp: true,
+        tls: true,
+        network: 'xhttp',
+        encryption: 'none',
+        'packet-encoding': 'xudp',
+        'xhttp-opts': {
+          path: '/xhttp',
+          mode: 'auto',
+        },
+        'ech-opts': {
+          enable: true,
+          config: 'ech-config',
+        },
+      },
+    ],
+  )
+
+  t.deepEqual(
+    clash.getClashNodes([
+      {
+        alterId: '64',
+        hostname: '1.1.1.1',
+        method: 'auto',
+        network: 'xhttp',
+        nodeName: 'vmess-xhttp',
+        port: 8080,
+        type: NodeTypeEnum.Vmess,
+        uuid: '1386f85e-657b-4d6e-9d56-78badb75e1fd',
+      } as any,
+    ]),
+    [],
+  )
+
+  t.deepEqual(
+    clash.getClashNodes([
+      {
         nodeName: 'snell',
         type: NodeTypeEnum.Snell,
         hostname: '1.1.1.1',

--- a/src/utils/clash.ts
+++ b/src/utils/clash.ts
@@ -302,8 +302,8 @@ function nodeListMapper(nodeConfig: PossibleNodeConfigType) {
             )
             return null
           }
-          if (nodeConfig.xhttpOpts) {
-            vmessNode['xhttp-opts'] = nodeConfig.xhttpOpts
+          vmessNode['xhttp-opts'] = nodeConfig.xhttpOpts || {
+            path: '/',
           }
           break
       }

--- a/src/utils/clash.ts
+++ b/src/utils/clash.ts
@@ -214,6 +214,10 @@ function nodeListMapper(nodeConfig: PossibleNodeConfigType) {
           vmessNode.encryption = nodeConfig.encryption
         }
 
+        if (typeof nodeConfig.packetEncoding === 'string') {
+          vmessNode['packet-encoding'] = nodeConfig.packetEncoding
+        }
+
         if (nodeConfig.realityOpts) {
           vmessNode['reality-opts'] = {
             'public-key': nodeConfig.realityOpts.publicKey,
@@ -255,6 +259,9 @@ function nodeListMapper(nodeConfig: PossibleNodeConfigType) {
         if (nodeConfig.clientFingerprint) {
           vmessNode['client-fingerprint'] = nodeConfig.clientFingerprint
         }
+        if (nodeConfig.type === NodeTypeEnum.Vless && nodeConfig.echOpts) {
+          vmessNode['ech-opts'] = nodeConfig.echOpts
+        }
       }
 
       switch (nodeConfig.network) {
@@ -283,6 +290,20 @@ function nodeListMapper(nodeConfig: PossibleNodeConfigType) {
             vmessNode['grpc-opts'] = {
               'grpc-service-name': nodeConfig.grpcOpts.serviceName,
             }
+          }
+          break
+
+        case 'xhttp':
+          if ((nodeConfig as any).type !== NodeTypeEnum.Vless) {
+            logger.warn(
+              `mihomo 仅支持 VLESS 使用 xhttp 传输层，节点 ${
+                (nodeConfig as any).nodeName
+              } 会被省略`,
+            )
+            return null
+          }
+          if (nodeConfig.xhttpOpts) {
+            vmessNode['xhttp-opts'] = nodeConfig.xhttpOpts
           }
           break
       }

--- a/src/validators/vless.ts
+++ b/src/validators/vless.ts
@@ -8,7 +8,6 @@ import {
   TlsNodeConfigValidator,
 } from './common'
 import {
-  VmessNetworkValidator,
   VmessH2OptsValidator,
   VmessGRPCOptsValidator,
   VmessHttpOptsValidator,
@@ -17,11 +16,24 @@ import {
   VmessHttpUpgradeOptsValidator,
 } from './vmess'
 
+export const VlessNetworkValidator = z.union([
+  z.literal('tcp'),
+  z.literal('ws'),
+  z.literal('h2'),
+  z.literal('http'),
+  z.literal('grpc'),
+  z.literal('xhttp'),
+  z.literal('quic'),
+  z.literal('httpupgrade'),
+])
+
 export const VlessRealityOptsValidator = z.object({
   publicKey: z.string(),
   shortId: z.ostring(),
   spiderX: z.ostring(),
 })
+
+export const VlessXHTTPOptsValidator = z.record(z.any())
 
 export const VlessNodeConfigValidator = TlsNodeConfigValidator.extend({
   type: z.literal(NodeTypeEnum.Vless),
@@ -29,7 +41,7 @@ export const VlessNodeConfigValidator = TlsNodeConfigValidator.extend({
   port: PortValidator,
   method: z.literal('none'),
   uuid: z.string().uuid(),
-  network: VmessNetworkValidator.default('tcp'),
+  network: VlessNetworkValidator.default('tcp'),
   udpRelay: z.oboolean(),
   flow: z.ostring(),
   encryption: z.ostring(),
@@ -38,6 +50,9 @@ export const VlessNodeConfigValidator = TlsNodeConfigValidator.extend({
   h2Opts: VmessH2OptsValidator.optional(),
   httpOpts: VmessHttpOptsValidator.optional(),
   grpcOpts: VmessGRPCOptsValidator.optional(),
+  xhttpOpts: VlessXHTTPOptsValidator.optional(),
+  echOpts: VlessXHTTPOptsValidator.optional(),
+  packetEncoding: z.ostring(),
   quicOpts: VmessQuicOptsValidator.optional(),
   httpUpgradeOpts: VmessHttpUpgradeOptsValidator.optional(),
   realityOpts: VlessRealityOptsValidator.optional(),

--- a/src/validators/vless.ts
+++ b/src/validators/vless.ts
@@ -33,7 +33,13 @@ export const VlessRealityOptsValidator = z.object({
   spiderX: z.ostring(),
 })
 
-export const VlessXHTTPOptsValidator = z.record(z.any())
+export const VlessXHTTPOptsValidator = z
+  .object({
+    path: z.string(),
+  })
+  .passthrough()
+
+export const VlessECHPortsValidator = z.record(z.any())
 
 export const VlessNodeConfigValidator = TlsNodeConfigValidator.extend({
   type: z.literal(NodeTypeEnum.Vless),
@@ -51,7 +57,7 @@ export const VlessNodeConfigValidator = TlsNodeConfigValidator.extend({
   httpOpts: VmessHttpOptsValidator.optional(),
   grpcOpts: VmessGRPCOptsValidator.optional(),
   xhttpOpts: VlessXHTTPOptsValidator.optional(),
-  echOpts: VlessXHTTPOptsValidator.optional(),
+  echOpts: VlessECHPortsValidator.optional(),
   packetEncoding: z.ostring(),
   quicOpts: VmessQuicOptsValidator.optional(),
   httpUpgradeOpts: VmessHttpUpgradeOptsValidator.optional(),


### PR DESCRIPTION
Add vless xhttp support for clash/mihomo, wich is already supported by mihomo.
[https://wiki.metacubex.one/en/config/proxies/transport/#xhttp-opts](url)