### PR TITLE
为 surge snell 增加 ip-version 的支持

### DIFF
--- a/src/utils/surge.ts
+++ b/src/utils/surge.ts
@@ -220,7 +220,7 @@ function nodeListMapper(
             nodeConfig.port,
             ...pickAndFormatStringList(
               nodeConfig,
-              ['psk', 'obfs', 'obfsHost', 'version', 'reuse'],
+              ['psk', 'obfs', 'obfsHost', 'version', 'reuse', 'ipVersion'],
               {
                 keyFormat: 'kebabCase',
               },


### PR DESCRIPTION
RT，适用于如下的 snell proxy 定义

```
Some Snell Proxy = snell, 1.1.1.1, 1111, psk=111111, obfs=none, version=4, reuse=true, ip-version=v6-only, tfo=true, test-url=http://baidu.com
```

之前不支持 `ip-version`