### PR TITLE
allow snell 4/5 for clash

### DIFF
--- a/src/utils/clash.ts
+++ b/src/utils/clash.ts
@@ -328,7 +328,7 @@ function nodeListMapper(nodeConfig: PossibleNodeConfigType) {
 
     case NodeTypeEnum.Snell:
       // Istanbul ignore next
-      if (Number(nodeConfig.version) >= 4) {
+      if (Number(nodeConfig.version) >= 6) {
         logger.warn(
           `Clash 尚不支持 Snell v${nodeConfig.version}，节点 ${nodeConfig.nodeName} 会被省略。`,
         )


### PR DESCRIPTION
新版的 mihomo 等内核均已支持 snell 4 & 5