### PR TITLE
Add Loon AnyTLS block-quic support

### DIFF
--- a/docs/guide/custom-provider.md
+++ b/docs/guide/custom-provider.md
@@ -620,7 +620,7 @@ Clash 需要在配置中开启 `clashConfig.enableHysteria2`。
 
 > <Badge text="Surgio v3.13.0" vertical="middle" />
 
-当前支持为 Clash、Surge、sing-box 和 Quantumult X 生成 AnyTLS 节点。
+当前支持为 Clash、Surge、sing-box、Quantumult X 和 Loon 生成 AnyTLS 节点。Loon 需要 Build 945 或更高版本。
 
 ```json5
 {
@@ -630,6 +630,7 @@ Clash 需要在配置中开启 `clashConfig.enableHysteria2`。
   port: 443,
   password: 'password',
   udpRelay: false, // 可选
+  blockQuic: 'off', // 可选，Loon 输出为 block-quic=false
   sni: 'sni.example.com', // 可选
   realityOpts: {
     publicKey: 'public-key',
@@ -966,11 +967,13 @@ Surgio 不会验证名称是否有效
 - 类型：`string`
 - 默认值：`undefined`
 
-通过代理转发 QUIC 流量可能会导致性能问题。启用该选项将阻止 QUIC 流量，使客户端退回到传统的 HTTPS/TCP 协议。目前仅 Surge 支持这一特性。
+通过代理转发 QUIC 流量可能会导致性能问题。启用该选项将阻止 QUIC 流量，使客户端退回到传统的 HTTPS/TCP 协议。目前 Surge 和 Loon AnyTLS 支持这一特性。
 
 `auto`: 根据代理是否适合转发 QUIC 流量自动启用
 `on`: 强制阻止 QUIC 流量
 `off`: 不阻止 QUIC 流量
+
+Loon 仅支持布尔值，因此 `on` 和 `off` 分别输出为 `block-quic=true` 和 `block-quic=false`。`auto` 无法无损映射，Surgio 会省略该参数并输出警告。
 
 ### nodeConfig.multiplex
 

--- a/docs/guide/custom-template.md
+++ b/docs/guide/custom-template.md
@@ -407,10 +407,10 @@ getSingboxNodeNames(nodeList, netflixFilter);
 :::tip 提示
 
 - 第二个参数可选，可传入标准的过滤器或自定义的过滤器
-- 支持输出 Shadowsocks, Shadowsocksr, HTTPS, HTTP, Vmess, Trojan 节点
+- 支持输出 Shadowsocks, Shadowsocksr, HTTPS, HTTP, Vmess, Vless, Trojan, WireGuard, AnyTLS 节点
 :::
 
-生成符合 `[Proxy]` 规范的节点信息，使用时请参考 [文档](https://www.notion.so/1-9809ce5acf524d868affee8dd5fc0a6e)。
+生成符合 `[Proxy]` 规范的节点信息，使用时请参考 [Loon 节点文档](https://nsloon.app/docs/Node/)。
 
 示例：
 

--- a/src/utils/__tests__/loon.test.ts
+++ b/src/utils/__tests__/loon.test.ts
@@ -1,31 +1,92 @@
 import test from 'ava'
+import sinon from 'sinon'
+import { transports } from '@surgio/logger'
 
 import { NodeTypeEnum } from '../../types'
 import { ERR_INVALID_FILTER } from '../../constant'
 import { getLoonNodeNames, getLoonNodes } from '../loon'
 
-test('getLoonNodes', (t) => {
-  //anytls://5af6f92a-08d6-46b2-a142-4fcacae7c5fd@hkzz.yuyan.vin:11001?security=tls&type=tcp&packetEncoding=none&allowInsecure=1&sni=www.apple.com&udp=1&insecure=1&ecn=true&test_url=http%3A%2F%2F1.0.0.1%2Fgenerate_204#%5BYuYan%5D%20%F0%9F%87%AD%F0%9F%87%B0%20%E9%A6%99%E6%B8%AFA%7CBGP%E4%BC%98%E5%8C%96
+test('getLoonNodes AnyTLS', (t) => {
   t.is(
     getLoonNodes([
       {
         type: NodeTypeEnum.AnyTLS,
-        nodeName: '测试',
-        hostname: '1.1.1.1',
-        port: 443,
-        sni: 'sni',
+        nodeName: 'anytls',
+        hostname: 'example.com',
+        port: 8449,
+        sni: 'example.com',
         password: 'password',
-        udpRelay: false,
+        udpRelay: true,
         skipCertVerify: true,
+        blockQuic: 'on',
         idleSessionCheckInterval: 0,
         idleSessionTimeout: 0,
         minIdleSessions: 0,
         tfo: true,
       },
     ]),
-    //anytlsimac = AnyTLS,192.168.2.254,8443,"qwertyuiop",idle-session-check-interval=30,idle-session-timeout=30,min-idle-session=1,max-stream-count=1
-    '测试 = AnyTLS,1.1.1.1,443,"password",sni=sni,skip-cert-verify=true,idle-session-check-interval=0,idle-session-timeout=0,min-idle-session=0,fast-open=true',
+    'anytls = AnyTLS,example.com,8449,"password",sni=example.com,skip-cert-verify=true,udp=true,block-quic=true,fast-open=true',
   )
+  t.is(
+    getLoonNodes([
+      {
+        type: NodeTypeEnum.AnyTLS,
+        nodeName: 'anytls off',
+        hostname: 'example.com',
+        port: 8449,
+        password: 'password',
+        blockQuic: 'off',
+      },
+    ]),
+    'anytls off = AnyTLS,example.com,8449,"password",block-quic=false',
+  )
+  t.is(
+    getLoonNodes([
+      {
+        type: NodeTypeEnum.AnyTLS,
+        nodeName: 'anytls defaults',
+        hostname: 'example.com',
+        port: 8449,
+        password: 'password',
+      },
+    ]),
+    'anytls defaults = AnyTLS,example.com,8449,"password"',
+  )
+})
+
+test.serial('getLoonNodes AnyTLS omits automatic QUIC blocking', (t) => {
+  const log = sinon
+    .stub(transports.console, 'log')
+    .callsFake((info, callback) => {
+      t.is(info[Symbol.for('level')], 'warn')
+      t.regex(
+        info.message,
+        /Loon 不支持 AnyTLS 节点 anytls auto 的 blockQuic=auto/,
+      )
+      callback()
+    })
+
+  try {
+    t.is(
+      getLoonNodes([
+        {
+          type: NodeTypeEnum.AnyTLS,
+          nodeName: 'anytls auto',
+          hostname: 'example.com',
+          port: 8449,
+          password: 'password',
+          blockQuic: 'auto',
+        },
+      ]),
+      'anytls auto = AnyTLS,example.com,8449,"password"',
+    )
+    t.true(log.calledOnce)
+  } finally {
+    log.restore()
+  }
+})
+
+test('getLoonNodes', (t) => {
   t.is(
     getLoonNodes([
       {

--- a/src/utils/loon.ts
+++ b/src/utils/loon.ts
@@ -112,23 +112,17 @@ export const getLoonNodes = function (
             config.push('skip-cert-verify=true')
           }
 
-          if (nodeConfig.idleSessionCheckInterval !== undefined) {
-            config.push(
-              `idle-session-check-interval=${nodeConfig.idleSessionCheckInterval}`,
+          if (nodeConfig.udpRelay) {
+            config.push('udp=true')
+          }
+
+          if (nodeConfig.blockQuic === 'auto') {
+            logger.warn(
+              `Loon 不支持 AnyTLS 节点 ${nodeConfig.nodeName} 的 blockQuic=auto，将省略 block-quic 参数`,
             )
+          } else if (nodeConfig.blockQuic !== undefined) {
+            config.push(`block-quic=${nodeConfig.blockQuic === 'on'}`)
           }
-
-          if (nodeConfig.idleSessionTimeout !== undefined) {
-            config.push(`idle-session-timeout=${nodeConfig.idleSessionTimeout}`)
-          }
-
-          if (nodeConfig.minIdleSessions !== undefined) {
-            config.push(`min-idle-session=${nodeConfig.minIdleSessions}`)
-          }
-
-          /*if (nodeConfig.maxStreamCount !== undefined) {
-            config.push(`max-stream-count=${nodeConfig.maxStreamCount}`)
-          }*/
 
           if (nodeConfig.tfo) {
             config.push('fast-open=true')

--- a/test/cli.cli-test.ts.snap
+++ b/test/cli.cli-test.ts.snap
@@ -139,7 +139,7 @@ HTTPS = https,us.example.com,443,username,\\"password\\",sni=us.example.com,skip
 trojan node = trojan,trojan.example.com,443,\\"password\\",sni=trojan.example.com,skip-cert-verify=false
 🚀 火箭 trojan node = trojan,trojan.example.com,443,\\"password\\",sni=trojan.example.com,skip-cert-verify=false
 🎉 foobar trojan node = trojan,trojan.example.com,443,\\"password\\",sni=trojan.example.com,skip-cert-verify=false
-anytls node = AnyTLS,anytls.example.com,443,\\"password\\",idle-session-check-interval=0,idle-session-timeout=0,min-idle-session=0
+anytls node = AnyTLS,anytls.example.com,443,\\"password\\"
 🇺🇸US 1 = Shadowsocks,us.example.com,443,chacha20-ietf-poly1305,\\"password\\",tls,gateway-carry.icloud.com
 🇺🇸US 2 = Shadowsocks,us.example.com,444,chacha20-ietf-poly1305,\\"password\\"
 🇺🇸US 3 = Shadowsocks,us.example.com,445,chacha20-ietf-poly1305,\\"password\\",tls,www.bing.com


### PR DESCRIPTION
## Summary
- Add Loon support documentation for AnyTLS nodes and `blockQuic` behavior.
- Update Loon node generation to emit UDP relay and boolean `block-quic` options.
- Warn and omit `block-quic` when `blockQuic=auto`, and refresh related tests and CLI snapshots.
- Document additional Loon proxy types and link to the Loon node reference.

## Testing
- Added AVA coverage for AnyTLS option mapping, defaults, and `blockQuic=auto` warnings.
- Updated the CLI snapshot for the revised AnyTLS output.