### PR TITLE
为 Loon 增加 Hysteria 2 节点输出支持

### DIFF
--- a/docs/guide/custom-provider.md
+++ b/docs/guide/custom-provider.md
@@ -598,9 +598,11 @@ sing-box 将 Tailscale 视为 [endpoint](https://sing-box.sagernet.org/configura
 
 > <Badge text="Surgio v3.1.0" vertical="middle" />
 
-Surgio 只支持 Hysteria v2 协议。请注意，Hysteria v2 协议和 v1 协议完全不兼容。当前可以为 Clash 和 Surge 生成此节点。
+Surgio 只支持 Hysteria v2 协议。请注意，Hysteria v2 协议和 v1 协议完全不兼容。当前可以为 Clash、Surge、sing-box 和 Loon 生成此节点。
 
 Clash 需要在配置中开启 `clashConfig.enableHysteria2`。
+
+Loon 支持输出 `sni`、`skipCertVerify`、`tfo`、`obfsPassword` 和 `udpRelay`。Loon 文档未支持的带宽、端口跳跃和 `alpn` 参数不会输出。
 
 ```json5
 {
@@ -611,8 +613,12 @@ Clash 需要在配置中开启 `clashConfig.enableHysteria2`。
   password: 'password',
   downloadBandwidth: 40, // 可选，Mbps
   uploadBandwidth: 40, // 可选，Mbps
+  obfs: 'salamander', // 可选
+  obfsPassword: 'obfs-password', // 可选，Loon 输出为 salamander-password
   sni: 'sni.example.com', // 可选
   skipCertVerify: true, // 可选
+  tfo: true, // 可选，Loon 输出为 fast-open=true
+  udpRelay: true, // 可选，Loon 输出为 udp=true
 }
 ```
 

--- a/docs/guide/custom-template.md
+++ b/docs/guide/custom-template.md
@@ -407,7 +407,7 @@ getSingboxNodeNames(nodeList, netflixFilter);
 :::tip 提示
 
 - 第二个参数可选，可传入标准的过滤器或自定义的过滤器
-- 支持输出 Shadowsocks, Shadowsocksr, HTTPS, HTTP, Vmess, Vless, Trojan, WireGuard, AnyTLS 节点
+- 支持输出 Shadowsocks, Shadowsocksr, HTTPS, HTTP, Vmess, Vless, Trojan, WireGuard, Hysteria 2, AnyTLS 节点
 :::
 
 生成符合 `[Proxy]` 规范的节点信息，使用时请参考 [Loon 节点文档](https://nsloon.app/docs/Node/)。

--- a/src/utils/__tests__/loon.test.ts
+++ b/src/utils/__tests__/loon.test.ts
@@ -6,6 +6,45 @@ import { NodeTypeEnum } from '../../types'
 import { ERR_INVALID_FILTER } from '../../constant'
 import { getLoonNodeNames, getLoonNodes } from '../loon'
 
+test('getLoonNodes Hysteria2', (t) => {
+  t.is(
+    getLoonNodes([
+      {
+        type: NodeTypeEnum.Hysteria2,
+        nodeName: 'hysteria2',
+        hostname: 'example.com',
+        port: 9898,
+        password: 'pa"ssword',
+        sni: 'sni.example.com',
+        skipCertVerify: true,
+        tfo: true,
+        obfs: 'salamander',
+        obfsPassword: 'obfs"password',
+        udpRelay: true,
+        downloadBandwidth: 100,
+        uploadBandwidth: 50,
+        portHopping: '5000-6000',
+        portHoppingInterval: 10,
+        alpn: ['h3'],
+      },
+    ]),
+    'hysteria2 = Hysteria2,example.com,9898,"pa\\"ssword",sni=sni.example.com,skip-cert-verify=true,fast-open=true,salamander-password="obfs\\"password",udp=true',
+  )
+
+  t.is(
+    getLoonNodes([
+      {
+        type: NodeTypeEnum.Hysteria2,
+        nodeName: 'hysteria2 minimal',
+        hostname: 'example.com',
+        port: 443,
+        password: 'password',
+      },
+    ]),
+    'hysteria2 minimal = Hysteria2,example.com,443,"password"',
+  )
+})
+
 test('getLoonNodes AnyTLS', (t) => {
   t.is(
     getLoonNodes([
@@ -370,7 +409,14 @@ test('getLoonNodeNames', (t) => {
         method: 'chacha20-ietf-poly1305',
         password: 'password',
       },
+      {
+        nodeName: 'Hysteria 2',
+        type: NodeTypeEnum.Hysteria2,
+        hostname: 'hysteria.example.com',
+        port: 443,
+        password: 'password',
+      },
     ]),
-    ['Test Node 1, Test Node 2'].join(', '),
+    ['Test Node 1, Test Node 2, Hysteria 2'].join(', '),
   )
 })

--- a/src/utils/loon.ts
+++ b/src/utils/loon.ts
@@ -23,6 +23,7 @@ const {
   wireguardFilter,
   vlessFilter,
   anytlsFilter,
+  hysteria2Filter,
 } = internalFilters
 const logger = createLogger({ service: 'surgio:utils:loon' })
 
@@ -87,6 +88,39 @@ export const getLoonNodes = function (
 
           if (nodeConfig.tfo) {
             config.push('fast-open=true')
+          }
+
+          if (nodeConfig.udpRelay) {
+            config.push('udp=true')
+          }
+
+          return config.join(',')
+        }
+
+        case NodeTypeEnum.Hysteria2: {
+          const config: Array<string | number> = [
+            `${nodeConfig.nodeName} = Hysteria2`,
+            nodeConfig.hostname,
+            nodeConfig.port,
+            JSON.stringify(nodeConfig.password),
+          ]
+
+          if (nodeConfig.sni) {
+            config.push(`sni=${nodeConfig.sni}`)
+          }
+
+          if (nodeConfig.skipCertVerify) {
+            config.push('skip-cert-verify=true')
+          }
+
+          if (nodeConfig.tfo) {
+            config.push('fast-open=true')
+          }
+
+          if (nodeConfig.obfsPassword) {
+            config.push(
+              `salamander-password=${JSON.stringify(nodeConfig.obfsPassword)}`,
+            )
           }
 
           if (nodeConfig.udpRelay) {
@@ -377,6 +411,7 @@ export const getLoonNodeNames = function (
     list.filter(
       (item) =>
         anytlsFilter(item) ||
+        hysteria2Filter(item) ||
         shadowsocksFilter(item) ||
         shadowsocksrFilter(item) ||
         vmessFilter(item) ||

--- a/src/validators/hysteria2.test.ts
+++ b/src/validators/hysteria2.test.ts
@@ -1,0 +1,18 @@
+import test from 'ava'
+
+import { NodeTypeEnum } from '../types'
+
+import { Hysteria2NodeConfigValidator } from './hysteria2'
+
+test('Hysteria2NodeConfigValidator preserves udpRelay', (t) => {
+  const result = Hysteria2NodeConfigValidator.parse({
+    type: NodeTypeEnum.Hysteria2,
+    nodeName: 'hysteria2',
+    hostname: 'example.com',
+    port: 443,
+    password: 'password',
+    udpRelay: true,
+  })
+
+  t.true(result.udpRelay)
+})

--- a/src/validators/hysteria2.ts
+++ b/src/validators/hysteria2.ts
@@ -11,4 +11,5 @@ export const Hysteria2NodeConfigValidator = TlsNodeConfigValidator.extend({
   uploadBandwidth: z.number().optional(),
   obfs: z.literal('salamander').optional(),
   obfsPassword: z.string().optional(),
+  udpRelay: z.oboolean(),
 })

--- a/test/cli.cli-test.ts.snap
+++ b/test/cli.cli-test.ts.snap
@@ -539,6 +539,7 @@ vmess custom header = vmess,server,443,chacha20-poly1305,\\"uuid\\",transport=ws
 http 1 = https,server,443,username,\\"password\\",sni=server,skip-cert-verify=false
 http 2 = http,server,443,username,\\"password\\"
 ss4 = Shadowsocks,server,443,chacha20-ietf-poly1305,\\"password\\",tls,example.com,udp=true
+hysteria2 = Hysteria2,server.com,443,\\"yourpassword\\",sni=server.com,salamander-password=\\"yourpassword\\"
 vless = VLESS,server.com,443,\\"uuid\\",transport=tcp,flow=xtls-rprx-vision,public-key=\\"666Kuy1l13XTLXaX2m9nV_s6JYRc8C3FRuAT15Bhaba\\",short-id=09561058,over-tls=true,sni=porter.server.com,udp=true
 ----
 proxyTestUrl


### PR DESCRIPTION
## 摘要

- 为 Loon 增加 Hysteria 2 节点输出支持
- 支持 SNI、证书校验、Fast Open、Salamander 混淆密码和 UDP Relay 参数
- 更新 Hysteria 2 验证器、文档及 CLI 快照

## 测试

- 新增 Loon Hysteria 2 输出与节点名称单元测试
- 新增 `udpRelay` 验证器单元测试